### PR TITLE
feat(FeedbackPanel): in-app feedback CTA + context-backed review state

### DIFF
--- a/src/FeedbackProvider.tsx
+++ b/src/FeedbackProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { FeedbackClient } from './api/feedback-client';
 import { ContextCollector } from './utils/context-collector';
 import type { FeedbackConfig, FeedbackUserInfo } from './types';
@@ -8,6 +8,17 @@ interface FeedbackContextValue {
   client: FeedbackClient;
   user: FeedbackUserInfo | null;
   contextCollector: ContextCollector;
+  /**
+   * Whether the review/screenshot-capture overlay is active. Lifted to
+   * the provider so `<FeedbackPanel>` (rendered inside any UI, e.g. the
+   * GundoWidget's feedback tab) can activate it without prop-drilling.
+   * `<ReviewMode>` reads this value when no explicit `active` prop is
+   * passed, so existing consumers that wired ReviewMode props directly
+   * keep working unchanged.
+   */
+  reviewActive: boolean;
+  activateReview: () => void;
+  deactivateReview: () => void;
 }
 
 const FeedbackContext = createContext<FeedbackContextValue | null>(null);
@@ -61,7 +72,14 @@ export function FeedbackProvider({
     [project, apiBaseUrl, getUser, modules, entityId, entityType],
   );
 
-  const value = useMemo(() => ({ config, client, user, contextCollector }), [config, client, user, contextCollector]);
+  const [reviewActive, setReviewActive] = useState(false);
+  const activateReview = useCallback(() => setReviewActive(true), []);
+  const deactivateReview = useCallback(() => setReviewActive(false), []);
+
+  const value = useMemo(
+    () => ({ config, client, user, contextCollector, reviewActive, activateReview, deactivateReview }),
+    [config, client, user, contextCollector, reviewActive, activateReview, deactivateReview],
+  );
 
   return <FeedbackContext.Provider value={value}>{children}</FeedbackContext.Provider>;
 }
@@ -71,3 +89,4 @@ export function useFeedbackContext() {
   if (!ctx) throw new Error('useFeedbackContext must be used within <FeedbackProvider>');
   return ctx;
 }
+

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -1,0 +1,128 @@
+import { useState, type CSSProperties, type ReactNode } from 'react';
+import { useFeedbackContext } from '../FeedbackProvider';
+import { theme as t } from '../utils/theme';
+
+interface FeedbackPanelProps {
+  /**
+   * Optional callback fired right before review mode activates. Hosts that
+   * embed FeedbackPanel inside another floating UI (e.g. the GundoWidget
+   * feedback tab) can use this to close the surrounding panel so the user
+   * sees the page they're about to mark, not a chat panel blocking it.
+   */
+  onBeforeActivate?: () => void;
+  /** Override the panel title (default Spanish copy aimed at testers) */
+  title?: string;
+  /** Override the body copy. Pass a node for richer formatting. */
+  description?: ReactNode;
+  /** Override the activate-button label */
+  buttonLabel?: string;
+  /** Override the message shown while review mode is already running */
+  activeMessage?: ReactNode;
+}
+
+/**
+ * Inline feedback CTA card. Render anywhere inside <FeedbackProvider> — most
+ * commonly as the `feedbackSlot` of @gundo/ui's GundoWidget — to expose the
+ * "mark a zone of the screen + leave feedback" flow without owning a
+ * standalone floating button (FeedbackToggle).
+ *
+ * Internal behavior: clicking the button flips `reviewActive` in
+ * FeedbackContext to `true`. A sibling <ReviewMode /> (already required for
+ * the toggle flow) then takes over the page — same UX as the toggle, just
+ * triggered from inside another widget instead of a fixed button.
+ */
+export function FeedbackPanel({
+  onBeforeActivate,
+  title = 'Reportá un problema o sugerencia',
+  description = (
+    <>
+      Vas a poder hacer clic en cualquier parte de la pantalla para
+      capturarla, dejar un comentario y mandarla al equipo. Útil para
+      bugs visuales, copy raro o ideas concretas.
+    </>
+  ),
+  buttonLabel = 'Marcar una zona y dejar feedback',
+  activeMessage = (
+    <>
+      Modo feedback activo. Hacé clic en cualquier parte de la pantalla
+      para capturarla.
+    </>
+  ),
+}: FeedbackPanelProps) {
+  const { reviewActive, activateReview } = useFeedbackContext();
+  const [hover, setHover] = useState(false);
+
+  const handleClick = () => {
+    onBeforeActivate?.();
+    activateReview();
+  };
+
+  const cardStyle: CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    padding: '16px',
+    fontFamily: t.fontFamily,
+    color: t.text,
+  };
+
+  const titleStyle: CSSProperties = {
+    margin: 0,
+    fontSize: '15px',
+    fontWeight: 600,
+    color: t.text,
+  };
+
+  const descStyle: CSSProperties = {
+    margin: 0,
+    fontSize: '13px',
+    lineHeight: 1.5,
+    color: t.textSecondary,
+  };
+
+  const buttonStyle: CSSProperties = {
+    marginTop: '4px',
+    padding: '10px 16px',
+    borderRadius: t.radiusLg,
+    border: 'none',
+    background: hover ? t.primaryHover : t.primary,
+    color: t.surface,
+    fontSize: '13px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    transition: 'background 0.15s ease',
+    fontFamily: t.fontFamily,
+  };
+
+  const activeBannerStyle: CSSProperties = {
+    padding: '12px 14px',
+    borderRadius: t.radiusLg,
+    border: `1px solid ${t.warning}`,
+    background: 'rgba(234,179,8,0.10)',
+    color: t.warning,
+    fontSize: '13px',
+    lineHeight: 1.5,
+  };
+
+  return (
+    <div style={cardStyle}>
+      <h3 style={titleStyle}>{title}</h3>
+      <p style={descStyle}>{description}</p>
+      {reviewActive ? (
+        <div style={activeBannerStyle} role="status">
+          {activeMessage}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={handleClick}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+          style={buttonStyle}
+        >
+          {buttonLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ReviewMode.tsx
+++ b/src/components/ReviewMode.tsx
@@ -7,9 +7,15 @@ import { theme as t } from '../utils/theme';
 // dependency on consumer's Tailwind CSS generating the required utility classes.
 
 interface ReviewModeProps {
-  /** Whether review mode is active */
-  active: boolean;
-  /** Called when user deactivates review mode */
+  /**
+   * Whether review mode is active. Optional since v1.3 — when omitted,
+   * ReviewMode falls back to the `reviewActive` state from
+   * FeedbackContext. This lets sibling components (e.g. <FeedbackPanel>
+   * inside another widget) activate review mode without prop-drilling.
+   * Explicit `active` still wins when passed.
+   */
+  active?: boolean;
+  /** Called when user deactivates review mode (in addition to clearing context state) */
   onDeactivate?: () => void;
   /** Override for section detection */
   currentSection?: string;
@@ -42,7 +48,14 @@ export function ReviewMode({
   types = DEFAULT_TYPES,
   captureSelector = 'main',
 }: ReviewModeProps) {
-  const { config, client, user, contextCollector } = useFeedbackContext();
+  const { config, client, user, contextCollector, reviewActive: ctxActive, deactivateReview } = useFeedbackContext();
+
+  // Prop wins when provided (legacy callers); otherwise read context state.
+  const isActive = active !== undefined ? active : ctxActive;
+  const handleDeactivate = useCallback(() => {
+    if (active === undefined) deactivateReview();
+    onDeactivate?.();
+  }, [active, deactivateReview, onDeactivate]);
 
   const [, setHoveredEl] = useState<HTMLElement | null>(null);
   const [highlightRect, setHighlightRect] = useState<DOMRect | null>(null);
@@ -85,7 +98,7 @@ export function ReviewMode({
   // ── Element highlighting on pointer move (desktop hover) ──
   const handlePointerMove = useCallback(
     (e: PointerEvent) => {
-      if (!active || showForm) return;
+      if (!isActive || showForm) return;
       // Only highlight on mouse hover, not touch drag
       if (e.pointerType === 'touch') return;
       const target = e.target as HTMLElement;
@@ -93,13 +106,13 @@ export function ReviewMode({
       setHoveredEl(target);
       setHighlightRect(target.getBoundingClientRect());
     },
-    [active, showForm],
+    [isActive, showForm],
   );
 
   // ── Pointer down: highlight element (works for both mouse and touch) ──
   const handlePointerDown = useCallback(
     (e: PointerEvent) => {
-      if (!active || showForm) return;
+      if (!isActive || showForm) return;
       const target = e.target as HTMLElement;
       if (target.closest('[data-review-mode]')) return;
       // On touch: show highlight on tap-down (replaces hover)
@@ -109,13 +122,13 @@ export function ReviewMode({
       }
       pointerDownTargetRef.current = target;
     },
-    [active, showForm],
+    [isActive, showForm],
   );
 
   // ── Pointer up: confirm selection and open form ──
   const handlePointerUp = useCallback(
     async (e: PointerEvent) => {
-      if (!active || showForm) return;
+      if (!isActive || showForm) return;
       const target = e.target as HTMLElement;
       if (target.closest('[data-review-mode]')) return;
 
@@ -161,7 +174,7 @@ export function ReviewMode({
         setShowForm(true);
       }
     },
-    [active, showForm, captureSelector],
+    [isActive, showForm, captureSelector],
   );
 
   // ── Keyboard: Escape to close ──
@@ -170,18 +183,18 @@ export function ReviewMode({
       if (e.key === 'Escape') {
         if (showForm) {
           resetForm();
-        } else if (active) {
-          onDeactivate?.();
+        } else if (isActive) {
+          handleDeactivate();
         }
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [active, showForm, onDeactivate]);
+  }, [isActive, showForm, handleDeactivate]);
 
   // ── Pointer listeners (unified mouse + touch + pen) ──
   useEffect(() => {
-    if (!active) return;
+    if (!isActive) return;
     document.addEventListener('pointermove', handlePointerMove);
     document.addEventListener('pointerdown', handlePointerDown, true);
     document.addEventListener('pointerup', handlePointerUp, true);
@@ -190,7 +203,7 @@ export function ReviewMode({
       document.removeEventListener('pointerdown', handlePointerDown, true);
       document.removeEventListener('pointerup', handlePointerUp, true);
     };
-  }, [active, handlePointerMove, handlePointerDown, handlePointerUp]);
+  }, [isActive, handlePointerMove, handlePointerDown, handlePointerUp]);
 
   function resetForm() {
     setShowForm(false);
@@ -269,7 +282,7 @@ export function ReviewMode({
     return () => clearTimeout(t);
   }, [toast]);
 
-  if (!active) return null;
+  if (!isActive) return null;
 
   const highlightStyle: CSSProperties | undefined = highlightRect && !showForm
     ? {
@@ -553,7 +566,7 @@ export function ReviewMode({
           <span>{isTouchDevice ? 'Toca cualquier elemento' : 'Click en cualquier elemento'}</span>
           <button
             data-review-mode
-            onClick={onDeactivate}
+            onClick={handleDeactivate}
             style={{
               background: 'rgba(255,255,255,0.2)',
               border: 'none',

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type { UseFeedbackSubmitReturn } from './hooks/useFeedbackSubmit';
 // ── Components ──────────────────────────────────────────────────
 export { ReviewMode } from './components/ReviewMode';
 export { FeedbackToggle } from './components/FeedbackToggle';
+export { FeedbackPanel } from './components/FeedbackPanel';
 export { FeedbackItemCard } from './components/FeedbackItemCard';
 export { CommentThread } from './components/CommentThread';
 export { FeedbackDashboard } from './components/FeedbackDashboard';


### PR DESCRIPTION
## Summary

Adds \`<FeedbackPanel>\` — a non-floating feedback CTA card meant to live inside another widget (e.g. the GundoWidget's feedback tab) instead of the standalone \`FeedbackToggle\` button.

Magui 28-may: testing the chat bubble in ultraperso flagged that the screenshot/annotation flow was no longer reachable when we retired \`FeedbackToggle\` in the bubble rollout. This restores it inside the bubble.

## How

- \`FeedbackProvider\` now holds the \`reviewActive\` boolean + \`activateReview\` / \`deactivateReview\` callbacks in context. **Backwards compatible** — existing consumers that pass \`active\` to ReviewMode still work; the prop wins when provided.
- \`ReviewMode\` reads \`reviewActive\` from context when \`active\` prop is omitted. Its \`onDeactivate\` now also clears the context flag.
- \`FeedbackPanel\` reads/writes via \`useFeedbackContext\`. Drop it inside any FeedbackProvider tree.

## UX

Same review/screenshot flow, triggered from inside another widget. ReviewMode's overlay (z-index 99998+) sits above the host widget, so:
1. User opens GundoWidget bubble → Feedback tab
2. Clicks "Marcar una zona y dejar feedback"
3. ReviewMode overlay activates; the widget stays open behind the blurred backdrop
4. User clicks any page element → screenshot + form → submit
5. ReviewMode closes; widget still where it was

## Test plan

- [ ] Build green
- [ ] Pubish v1.5.0 (auto via semantic-release on merge — feat: commit)
- [ ] Bump ultraperso to v1.5.0, wire \`feedbackSlot={<FeedbackPanel />}\` in GundoWidgetWrapper
- [ ] Magui smoke: open bubble → Feedback tab → start capture → mark zone → submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)