### PR TITLE
fix(ci): propagate — auto-detect consumer pnpm version (mirror gundo-ui #24)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,9 +116,33 @@ jobs:
           repository: ${{ matrix.repo }}
           token: ${{ secrets.SDK_PROPAGATE_TOKEN }}
 
+      # Same dance as gundo-ui propagate (PR #24, 2026-05-29):
+      # pnpm/action-setup@v4 errors out if `version` and `packageManager`
+      # are both set. Consumers (e.g. gundo-plataform-ui pins 10.11.0)
+      # have varying pnpm versions in their `packageManager` field. The
+      # hardcoded 10.30.1 here was breaking gundo-admin-fitness-ui and
+      # Gundo_Engine on the v1.5.0 release. Strategy: point the action
+      # at the matrix's pkg_dir/package.json; if that has packageManager
+      # pass empty version (auto-detect), else fall back to 10.30.1.
+      - name: Resolve pnpm config
+        id: pnpm-version
+        run: |
+          PKG="package.json"
+          if [ "${{ matrix.pkg_dir }}" != "." ]; then PKG="${{ matrix.pkg_dir }}/package.json"; fi
+          HAS_PM=$(node -p "!!require('./'+'$PKG').packageManager" 2>/dev/null || echo "false")
+          echo "pkg_file=$PKG" >> "$GITHUB_OUTPUT"
+          if [ "$HAS_PM" = "true" ]; then
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "Source: packageManager field in $PKG (auto-detect)"
+          else
+            echo "version=10.30.1" >> "$GITHUB_OUTPUT"
+            echo "Source: workflow fallback (no packageManager in $PKG)"
+          fi
+
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.30.1
+          version: ${{ steps.pnpm-version.outputs.version }}
+          package_json_file: ${{ steps.pnpm-version.outputs.pkg_file }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Why

Hardcoded \`version: 10.30.1\` in the propagate step broke v1.5.0 release for consumers that pin a different pnpm in their \`packageManager\` field — gundo-admin-fitness-ui pins 10.11.0, Gundo_Engine's frontend has its own.

Same root cause + same fix as gundo-ui PR #24 (2026-05-29).

## What changed

Detect \`packageManager\` in the consumer's \`\${matrix.pkg_dir}/package.json\`:
- If present → pass empty \`version\` + point \`pnpm/action-setup\` at that file (auto-detect)
- If absent → fall back to 10.30.1

## Test plan

- [ ] Merge → triggers v1.5.1 release
- [ ] Propagate succeeds for all 7 consumers (including admin-fitness-ui + Gundo_Engine that failed in v1.5.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)