### PR TITLE
fix(review-mode): force dark color-scheme + text contrast on inputs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,9 +116,33 @@ jobs:
           repository: ${{ matrix.repo }}
           token: ${{ secrets.SDK_PROPAGATE_TOKEN }}
 
+      # Same dance as gundo-ui propagate (PR #24, 2026-05-29):
+      # pnpm/action-setup@v4 errors out if `version` and `packageManager`
+      # are both set. Consumers (e.g. gundo-plataform-ui pins 10.11.0)
+      # have varying pnpm versions in their `packageManager` field. The
+      # hardcoded 10.30.1 here was breaking gundo-admin-fitness-ui and
+      # Gundo_Engine on the v1.5.0 release. Strategy: point the action
+      # at the matrix's pkg_dir/package.json; if that has packageManager
+      # pass empty version (auto-detect), else fall back to 10.30.1.
+      - name: Resolve pnpm config
+        id: pnpm-version
+        run: |
+          PKG="package.json"
+          if [ "${{ matrix.pkg_dir }}" != "." ]; then PKG="${{ matrix.pkg_dir }}/package.json"; fi
+          HAS_PM=$(node -p "!!require('./'+'$PKG').packageManager" 2>/dev/null || echo "false")
+          echo "pkg_file=$PKG" >> "$GITHUB_OUTPUT"
+          if [ "$HAS_PM" = "true" ]; then
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "Source: packageManager field in $PKG (auto-detect)"
+          else
+            echo "version=10.30.1" >> "$GITHUB_OUTPUT"
+            echo "Source: workflow fallback (no packageManager in $PKG)"
+          fi
+
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.30.1
+          version: ${{ steps.pnpm-version.outputs.version }}
+          package_json_file: ${{ steps.pnpm-version.outputs.pkg_file }}
 
       - uses: actions/setup-node@v4
         with:

--- a/src/components/ReviewMode.tsx
+++ b/src/components/ReviewMode.tsx
@@ -352,7 +352,7 @@ export function ReviewMode({
             fontFamily: t.fontFamily,
             fontSize: '16px',
             paddingBottom: 'env(safe-area-inset-bottom, 0px)',
-            // Inject CSS custom properties so @gundo/ui components resolve tokens correctly
+            colorScheme: 'dark',
             '--ui-surface': '#292E37',
             '--ui-surface-hover': 'rgba(255,255,255,0.07)',
             '--ui-text': '#F2F4F3',
@@ -364,6 +364,36 @@ export function ReviewMode({
             '--ui-primary-hover': '#5ab322',
           } as CSSProperties}
         >
+          <style>{`
+            [data-review-mode] textarea,
+            [data-review-mode] input,
+            [data-review-mode] select {
+              color: #F2F4F3 !important;
+              -webkit-text-fill-color: #F2F4F3 !important;
+              caret-color: #67C728;
+              color-scheme: dark;
+            }
+            [data-review-mode] textarea::placeholder,
+            [data-review-mode] input::placeholder {
+              color: #9ca3af !important;
+              opacity: 1;
+            }
+            [data-review-mode] textarea::selection,
+            [data-review-mode] input::selection {
+              background: rgba(103,199,40,0.35);
+              color: #F2F4F3;
+            }
+            [data-review-mode] select option {
+              background: #292E37;
+              color: #F2F4F3;
+            }
+            [data-review-mode] textarea:-webkit-autofill,
+            [data-review-mode] input:-webkit-autofill {
+              -webkit-text-fill-color: #F2F4F3 !important;
+              -webkit-box-shadow: 0 0 0 1000px #292E37 inset !important;
+              caret-color: #F2F4F3;
+            }
+          `}</style>
           {/* Header */}
           <div style={{ padding: '16px 20px', borderBottom: `1px solid ${t.border}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <span style={{ fontWeight: 600, fontSize: '16px' }}>Nuevo Feedback</span>


### PR DESCRIPTION
## Bug

Magui reporta que en el panel de feedback (review-mode drawer) el textarea muestra texto **negro sobre fondo negro** — no puede leer lo que escribe.

## Root cause

El panel inyecta `--ui-text: #F2F4F3` y aplica `color: t.text` en el textarea, **pero Chrome resuelve el color de los form controls nativos** (textarea/input/select) usando el `color-scheme` heredado del consumer app (light), no el `color` CSS aplicado al elemento. Sin `color-scheme: dark`, además, el browser pisa caret, placeholder, autofill y scrollbars con variants light.

## Fix

1. `colorScheme: 'dark'` en el root del panel → controles nativos usan variants oscuros.
2. `<style>` block scopeado a `[data-review-mode]` con `!important` para:
   - `color: #F2F4F3` + `-webkit-text-fill-color` en textarea/input/select
   - `caret-color: #67C728`
   - `::placeholder` color claro (#9ca3af) con opacity 1
   - `::selection` con color brand
   - `select option` background oscuro + texto claro
   - Webkit autofill override (box-shadow inset + text-fill-color)

## Test plan

- [x] `pnpm build` → dist verificado
- [ ] Post-publish: bump consumer (ultraperso.gundo.life), redeploy, Magui re-testea

🤖 Generated with [Claude Code](https://claude.com/claude-code)