### PR TITLE
feat(screenshot): redact health/PII regions from feedback captures (GDPR Art.9)

### DIFF
--- a/src/FeedbackProvider.tsx
+++ b/src/FeedbackProvider.tsx
@@ -19,6 +19,13 @@ interface FeedbackContextValue {
   reviewActive: boolean;
   activateReview: () => void;
   deactivateReview: () => void;
+  /**
+   * Extra CSS selectors for sensitive regions (health data, PII) that must be
+   * dropped from feedback screenshots. The defaults `[data-gundo-private]` /
+   * `.gundo-private` always apply on top of these. `<ReviewMode>` forwards them
+   * to the screenshot capture.
+   */
+  privateSelectors: string[];
 }
 
 const FeedbackContext = createContext<FeedbackContextValue | null>(null);
@@ -39,6 +46,13 @@ interface FeedbackProviderProps {
   entityType?: string;
   /** Optional: returns custom app context (Redux state, feature flags, build version) */
   getCustomContext?: () => Record<string, unknown>;
+  /**
+   * Optional CSS selectors for sensitive regions (health data, PII) to exclude
+   * from feedback screenshots. Use this to centrally redact health zones without
+   * tagging every element (e.g. `['[data-test-result]', '.health-panel']`).
+   * `[data-gundo-private]` / `.gundo-private` are always excluded regardless.
+   */
+  privateSelectors?: string[];
   children: ReactNode;
 }
 
@@ -51,6 +65,7 @@ export function FeedbackProvider({
   entityId,
   entityType,
   getCustomContext,
+  privateSelectors,
   children,
 }: FeedbackProviderProps) {
   const client = useMemo(() => new FeedbackClient(apiBaseUrl, getToken), [apiBaseUrl, getToken]);
@@ -76,9 +91,26 @@ export function FeedbackProvider({
   const activateReview = useCallback(() => setReviewActive(true), []);
   const deactivateReview = useCallback(() => setReviewActive(false), []);
 
+  // Stabilize across renders so memo deps don't churn on a fresh array literal.
+  const privateSelectorsKey = (privateSelectors ?? []).join('|');
+  const stablePrivateSelectors = useMemo(
+    () => privateSelectors ?? [],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [privateSelectorsKey],
+  );
+
   const value = useMemo(
-    () => ({ config, client, user, contextCollector, reviewActive, activateReview, deactivateReview }),
-    [config, client, user, contextCollector, reviewActive, activateReview, deactivateReview],
+    () => ({
+      config,
+      client,
+      user,
+      contextCollector,
+      reviewActive,
+      activateReview,
+      deactivateReview,
+      privateSelectors: stablePrivateSelectors,
+    }),
+    [config, client, user, contextCollector, reviewActive, activateReview, deactivateReview, stablePrivateSelectors],
   );
 
   return <FeedbackContext.Provider value={value}>{children}</FeedbackContext.Provider>;

--- a/src/components/ReviewMode.tsx
+++ b/src/components/ReviewMode.tsx
@@ -48,7 +48,7 @@ export function ReviewMode({
   types = DEFAULT_TYPES,
   captureSelector = 'main',
 }: ReviewModeProps) {
-  const { config, client, user, contextCollector, reviewActive: ctxActive, deactivateReview } = useFeedbackContext();
+  const { config, client, user, contextCollector, reviewActive: ctxActive, deactivateReview, privateSelectors } = useFeedbackContext();
 
   // Prop wins when provided (legacy callers); otherwise read context state.
   const isActive = active !== undefined ? active : ctxActive;
@@ -161,7 +161,7 @@ export function ReviewMode({
       document.documentElement.style.cursor = 'progress';
 
       try {
-        const blob = await captureElementScreenshot(captureEl);
+        const blob = await captureElementScreenshot(captureEl, { privateSelectors });
         setScreenshotBlob(blob);
         setScreenshotPreview(URL.createObjectURL(blob));
       } catch (err) {
@@ -174,7 +174,7 @@ export function ReviewMode({
         setShowForm(true);
       }
     },
-    [isActive, showForm, captureSelector],
+    [isActive, showForm, captureSelector, privateSelectors],
   );
 
   // ── Keyboard: Escape to close ──

--- a/src/utils/screenshot-capture.ts
+++ b/src/utils/screenshot-capture.ts
@@ -10,11 +10,53 @@
  *   pnpm add html-to-image
  */
 
+export interface CaptureOptions {
+  /**
+   * CSS selectors for elements the host app marks as sensitive (health data,
+   * PII). They are dropped from the screenshot — the SDK never rasterizes them.
+   * The defaults `[data-gundo-private]` / `.gundo-private` always apply on top
+   * of whatever is passed here.
+   */
+  privateSelectors?: string[];
+}
+
+// Always-on markers: SDK consumers can opt any region out of capture with zero
+// config, and the SDK's own overlays are skipped so they don't get rasterized.
+const ALWAYS_EXCLUDED_SELECTORS = ['[data-gundo-private]', '.gundo-private'];
+
+/**
+ * True if a node must be kept out of the screenshot:
+ * - the SDK's own overlays (`data-review-mode`),
+ * - anything marked private by default markers or by the host's `privateSelectors`.
+ * Excluding a node also excludes its subtree (both renderers stop recursing into
+ * a dropped node), so marking a container is enough to redact everything inside.
+ * Health / PII regions in GUNDO apps are marked private to stay out of feedback
+ * screenshots (GDPR Art. 9).
+ */
+function isExcludedFromCapture(node: unknown, privateSelectors: string[]): boolean {
+  if (!(node instanceof HTMLElement)) return false;
+  if (node.dataset?.reviewMode !== undefined) return true;
+  for (const sel of privateSelectors) {
+    if (!sel) continue;
+    try {
+      if (node.matches(sel)) return true;
+    } catch {
+      // Ignore invalid selectors rather than failing the whole capture.
+    }
+  }
+  return false;
+}
+
 /**
  * Capture a screenshot of an HTML element.
  * Tries html-to-image first (modern CSS compatible), falls back to html2canvas.
  */
-export async function captureElementScreenshot(element: HTMLElement): Promise<Blob> {
+export async function captureElementScreenshot(
+  element: HTMLElement,
+  options: CaptureOptions = {},
+): Promise<Blob> {
+  const privateSelectors = [...ALWAYS_EXCLUDED_SELECTORS, ...(options.privateSelectors ?? [])];
+
   // Attempt 1: html-to-image (preferred — supports oklch, oklab, modern CSS)
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -27,10 +69,9 @@ export async function captureElementScreenshot(element: HTMLElement): Promise<Bl
         pixelRatio: 1,
         skipFonts: true,
         cacheBust: false,
-        // Skip the SDK's own overlays (highlight, form panel, toggle button)
-        // so they don't end up rasterized inside the screenshot.
-        filter: (node: HTMLElement) =>
-          !(node?.dataset && node.dataset.reviewMode !== undefined),
+        // Skip the SDK's own overlays (highlight, form panel, toggle button) and
+        // any host-marked private regions so they don't end up in the screenshot.
+        filter: (node: HTMLElement) => !isExcludedFromCapture(node, privateSelectors),
       });
       const blob = dataUrlToBlob(dataUrl);
       if (blob && blob.size > 0) return blob;
@@ -52,8 +93,7 @@ export async function captureElementScreenshot(element: HTMLElement): Promise<Bl
       useCORS: true,
       allowTaint: true,
       logging: false,
-      ignoreElements: (el: Element) =>
-        el instanceof HTMLElement && el.dataset?.reviewMode !== undefined,
+      ignoreElements: (el: Element) => isExcludedFromCapture(el, privateSelectors),
     });
     return canvasToBlob(canvas);
   } catch (err) {
@@ -96,8 +136,8 @@ function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
 /**
  * Capture a screenshot of the visible viewport area.
  */
-export async function captureViewportScreenshot(): Promise<Blob> {
-  return captureElementScreenshot(document.body);
+export async function captureViewportScreenshot(options: CaptureOptions = {}): Promise<Blob> {
+  return captureElementScreenshot(document.body, options);
 }
 
 /**


### PR DESCRIPTION
## Problem
Feedback screenshots (html-to-image / html2canvas) could rasterize **health data** — blood/urine/genetic results, conditions, allergies, medication — and ship it to the feedback store. WS-1 P1 gap.

## Fix
The SDK can't know what's sensitive, so it drops any region the host marks private, in **both** renderers (`filter` + `ignoreElements`). Excluding a node excludes its whole subtree.

- **Zero config:** `[data-gundo-private]` and `.gundo-private` are always excluded.
- **Central config:** `FeedbackProvider` accepts `privateSelectors?: string[]` so a host can redact health zones by selector without tagging every element (e.g. `['[data-test-result]', '.health-panel']`). Threaded via context → ReviewMode → `captureElementScreenshot`.

## Compat
No change for existing consumers — the SDK's own `data-review-mode` overlays stay excluded as before. `tsc --noEmit` clean.

## Follow-up
Consumers (ecom/vida) should mark health zones with `data-gundo-private` or pass `privateSelectors` once they bump the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)