### PR TITLE
feat(types): campo rating NPS + tipo 'nps' (WS2-03)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 // ── Feedback Hub SDK Types ──────────────────────────────────────
 
-export type FeedbackType = 'text_selection' | 'image_area' | 'general' | 'bug' | 'improvement' | 'feature';
+export type FeedbackType = 'text_selection' | 'image_area' | 'general' | 'bug' | 'improvement' | 'feature' | 'nps';
 export type FeedbackPriority = 'critical' | 'high' | 'medium' | 'low';
 export type FeedbackStatus = 'pending' | 'in_progress' | 'applied' | 'resolved' | 'dismissed' | 'wontfix';
 export type FeedbackSeverity = 'critical' | 'suggestion' | 'question';
@@ -41,6 +41,8 @@ export interface FeedbackItem {
   entityId: string | null;
   entityType: string | null;
   screenshotUrl: string | null;
+  /** NPS / satisfaction score (0–10) when feedbackType is 'nps'; null otherwise. */
+  rating: number | null;
   context: Record<string, unknown>;
   aiAnalysis: AiAnalysis | null;
   status: FeedbackStatus;
@@ -188,6 +190,8 @@ export interface FeedbackUserInfo {
 export interface CreateFeedbackItemInput {
   comment: string;
   feedbackType?: FeedbackType;
+  /** NPS / satisfaction score (0–10). Set together with feedbackType: 'nps'. */
+  rating?: number;
   title?: string;
   module?: string;
   priority?: FeedbackPriority;


### PR DESCRIPTION
## Qué
Primera capa (datos) de la captura de NPS (WS2-03, Option A): habilita guardar un score numérico NPS vía el SDK.

- `CreateFeedbackItemInput.rating?: number` (0–10)
- `FeedbackItem.rating: number | null`
- Nuevo `FeedbackType` `'nps'`

El `FeedbackClient.submitFeedback` serializa el item tal cual → no requiere cambios en el cliente HTTP. Backward-compatible (rating opcional/nullable).

## Siguiente
- Hub: columna `rating` + validador DTO (PR aparte en gundo-feedback).
- Chatbot (GundoWidget @gundo/ui): surface conversacional 0–10 + submit (fase con decisiones de diseño, a alinear).

## Publish
Semantic-release publica un minor nuevo al mergear a main (commit `feat:`). Consumers suben el rango después.

🤖 Generated with [Claude Code](https://claude.com/claude-code)